### PR TITLE
Rewrite existing code

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,5 +22,5 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
 }


### PR DESCRIPTION
Update `globals.css` to use `var(--font-sans)` for body font.

This change ensures the Geist font loaded via `next/font` is correctly applied, as the previous `font-family` declaration was overriding it.

---
<a href="https://cursor.com/background-agent?bcId=bc-84acd6bd-1e90-4da9-976b-aeeac5db1dd1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-84acd6bd-1e90-4da9-976b-aeeac5db1dd1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

